### PR TITLE
Refactor for multithreaded use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,12 +475,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "sp-wasm"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-wasm-engine 0.3.0",
+ "sp-wasm-engine 0.4.0",
  "structopt 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "sp-wasm-engine"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "itertools 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "sp-wasm"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Jakub Konka <jakub.konka@golem.network>"]
 edition = "2018"
 
 [dependencies]
-sp-wasm-engine = { path = "sp-wasm-engine", version = "0.3.0" }
+sp-wasm-engine = { path = "sp-wasm-engine", version = "0.4.0" }
 serde = { version = "1", features = ["derive"] }
 env_logger = "0.6"
 log = "0.4"

--- a/sp-wasm-engine/Cargo.toml
+++ b/sp-wasm-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-wasm-engine"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Jakub Konka <jakub.konka@golem.network>"]
 edition = "2018"
 license = "GPL-3.0"

--- a/sp-wasm-engine/src/lib.rs
+++ b/sp-wasm-engine/src/lib.rs
@@ -10,4 +10,5 @@ pub mod prelude {
     pub use super::sandbox::engine::Engine;
     pub use super::sandbox::vfs::VirtualFS;
     pub use super::sandbox::Sandbox;
+    pub use mozjs::rust::JSEngine;
 }

--- a/sp-wasm-engine/src/lib.rs
+++ b/sp-wasm-engine/src/lib.rs
@@ -7,8 +7,7 @@ pub mod sandbox;
 pub use error::{Error, Result};
 
 pub mod prelude {
-    pub use super::sandbox::engine::Engine;
+    pub use super::sandbox::engine::{Engine, Runtime};
     pub use super::sandbox::vfs::VirtualFS;
     pub use super::sandbox::Sandbox;
-    pub use mozjs::rust::JSEngine;
 }

--- a/sp-wasm-engine/src/sandbox/engine.rs
+++ b/sp-wasm-engine/src/sandbox/engine.rs
@@ -19,10 +19,10 @@ use mozjs::{
 };
 use std::{
     ffi,
+    ops::Deref,
     os::raw::c_uint,
     ptr::{self, NonNull},
     sync::Arc,
-    ops::Deref,
 };
 
 const STACK_QUOTA: usize = 128 * 8 * 1024;

--- a/sp-wasm-engine/src/sandbox/engine.rs
+++ b/sp-wasm-engine/src/sandbox/engine.rs
@@ -109,7 +109,6 @@ pub fn evaluate_script(
 }
 
 pub struct Engine {
-    _engine: Arc<JSEngine>,
     ctx: NonNull<JSContext>,
     global: NonNull<JSObject>,
 }
@@ -125,18 +124,16 @@ impl Drop for Engine {
 }
 
 impl Engine {
-    pub fn new() -> Result<Self> {
-        log::info!("Initializing SpiderMonkey engine");
-        let engine = JSEngine::init().map_err(error::Error::from)?;
-
+    pub fn new(_js_engine: Arc<JSEngine>) -> Result<Self> {
+        log::info!("Creating new Engine instance");
         unsafe {
             let ctx = new_root_context()?;
-            let engine = Self::create_with(engine, ctx)?;
+            let engine = Self::create_with(ctx)?;
             Ok(engine)
         }
     }
 
-    unsafe fn create_with(_engine: Arc<JSEngine>, ctx: NonNull<JSContext>) -> Result<Self> {
+    unsafe fn create_with(ctx: NonNull<JSContext>) -> Result<Self> {
         let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
         let c_option = CompartmentOptions::default();
         let ctx_ptr = ctx.as_ptr();
@@ -234,11 +231,7 @@ impl Engine {
              ",
         )?;
 
-        Ok(Self {
-            _engine,
-            ctx,
-            global,
-        })
+        Ok(Self { ctx, global })
     }
 
     unsafe fn eval<S>(

--- a/sp-wasm-engine/src/sandbox/mod.rs
+++ b/sp-wasm-engine/src/sandbox/mod.rs
@@ -6,25 +6,23 @@ use self::vfs::*;
 use super::Result;
 
 use std::path::{self, Path};
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 use itertools::Itertools;
 use lazy_static::lazy_static;
-use mozjs::rust::JSEngine;
 
 lazy_static! {
     static ref VFS: Mutex<VirtualFS> = Mutex::new(VirtualFS::default());
 }
 
 pub struct Sandbox {
-    engine: Engine,
+    runtime: Runtime,
 }
 
 impl Sandbox {
-    pub fn new(js_engine: Arc<JSEngine>) -> Result<Self> {
-        let engine = Engine::new(js_engine)?;
-
-        Ok(Self { engine })
+    pub fn new(engine: &Engine) -> Result<Self> {
+        let runtime = Runtime::new(engine)?;
+        Ok(Self { runtime })
     }
 
     pub fn set_exec_args<It>(self, exec_args: It) -> Result<Self>
@@ -39,7 +37,7 @@ impl Sandbox {
         log::info!("Setting exec args [ {} ]", exec_args);
 
         let js = format!("Module['arguments'] = [ {} ];", exec_args);
-        self.engine.evaluate_script(&js)?;
+        self.runtime.evaluate_script(&js)?;
 
         Ok(self)
     }
@@ -74,7 +72,7 @@ impl Sandbox {
             })?;
 
         js += "\n};";
-        self.engine.evaluate_script(&js)?;
+        self.runtime.evaluate_script(&js)?;
 
         Ok(self)
     }
@@ -93,7 +91,7 @@ impl Sandbox {
         let wasm_js = hostfs::read_file(wasm_js.as_ref())?;
         let wasm_js = String::from_utf8(wasm_js)?;
         js += &wasm_js;
-        self.engine.evaluate_script(&js)?;
+        self.runtime.evaluate_script(&js)?;
 
         Ok(self)
     }
@@ -118,7 +116,7 @@ impl Sandbox {
 
             // copy files from JS_FS to MemFS
             let output_vfs_path_str: String = output_vfs_path.as_path().to_string_lossy().into();
-            self.engine.evaluate_script(&format!(
+            self.runtime.evaluate_script(&format!(
                 "
                 try {{
                     writeFile('{}', FS.readFile('{}'));
@@ -151,7 +149,7 @@ impl Sandbox {
         Ok(())
     }
 
-    pub fn engine(&self) -> &Engine {
-        &self.engine
+    pub fn runtime(&self) -> &Runtime {
+        &self.runtime
     }
 }

--- a/sp-wasm-engine/src/sandbox/mod.rs
+++ b/sp-wasm-engine/src/sandbox/mod.rs
@@ -6,10 +6,11 @@ use self::vfs::*;
 use super::Result;
 
 use std::path::{self, Path};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use itertools::Itertools;
 use lazy_static::lazy_static;
+use mozjs::rust::JSEngine;
 
 lazy_static! {
     static ref VFS: Mutex<VirtualFS> = Mutex::new(VirtualFS::default());
@@ -20,8 +21,8 @@ pub struct Sandbox {
 }
 
 impl Sandbox {
-    pub fn new() -> Result<Self> {
-        let engine = Engine::new()?;
+    pub fn new(js_engine: Arc<JSEngine>) -> Result<Self> {
+        let engine = Engine::new(js_engine)?;
 
         Ok(Self { engine })
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,12 @@ fn main() {
     let opts = Opts::from_args();
     env_logger::init_from_env(env_logger::Env::default().default_filter_or("info"));
 
-    Sandbox::new()
+    let engine = Engine::new().unwrap_or_else(|err| {
+        eprintln!("{}", err);
+        std::process::exit(1)
+    });
+
+    Sandbox::new(&engine)
         .and_then(|sandbox| sandbox.set_exec_args(opts.args.iter()))
         .and_then(|sandbox| sandbox.load_input_files(&opts.input_dir))
         .and_then(|sandbox| sandbox.run(&opts.wasm_js, &opts.wasm_bin))

--- a/tests/date_test.rs
+++ b/tests/date_test.rs
@@ -3,8 +3,9 @@ use sp_wasm_engine::prelude::*;
 #[test]
 fn date() {
     let engine = Engine::new().unwrap();
-    let v1 = engine.evaluate_script("Date.now()").unwrap().to_number();
+    let runtime = Runtime::new(&engine).unwrap();
+    let v1 = runtime.evaluate_script("Date.now()").unwrap().to_number();
     assert_eq!(v1 as u64, 0);
-    let v2 = engine.evaluate_script("Date.now()").unwrap().to_number();
+    let v2 = runtime.evaluate_script("Date.now()").unwrap().to_number();
     assert_eq!(v1, v2);
 }

--- a/tests/gettimeofday_test.rs
+++ b/tests/gettimeofday_test.rs
@@ -31,7 +31,8 @@ fn gettimeofday_impl() -> Result<(), String> {
     output_dir.push("out/");
     fs::create_dir(output_dir.as_path()).map_err(|err| err.to_string())?;
 
-    Sandbox::new()
+    let engine = Engine::new().map_err(|err| err.to_string())?;
+    Sandbox::new(&engine)
         .and_then(|sandbox| sandbox.load_input_files(input_dir.to_str().unwrap()))
         .and_then(|sandbox| sandbox.run(js.to_str().unwrap(), wasm.to_str().unwrap()))
         .and_then(|sandbox| {

--- a/tests/random_device_determinism_test.rs
+++ b/tests/random_device_determinism_test.rs
@@ -2,7 +2,8 @@ use sp_wasm_engine::prelude::*;
 
 #[test]
 fn random_device_determinism() {
-    let start = Engine::new()
+    let engine = Engine::new().unwrap();
+    let start = Runtime::new(&engine)
         .unwrap()
         .evaluate_script("golem_randEmu()")
         .unwrap()

--- a/tests/random_device_emulation_test.rs
+++ b/tests/random_device_emulation_test.rs
@@ -3,15 +3,16 @@ use sp_wasm_engine::prelude::*;
 #[test]
 fn random_device_emulation() {
     let engine = Engine::new().unwrap();
-    let v1 = engine
+    let runtime = Runtime::new(&engine).unwrap();
+    let v1 = runtime
         .evaluate_script("golem_randEmu()")
         .unwrap()
         .to_number();
-    let v2 = engine
+    let v2 = runtime
         .evaluate_script("golem_randEmu()")
         .unwrap()
         .to_number();
-    let v3 = engine
+    let v3 = runtime
         .evaluate_script("golem_randEmu()")
         .unwrap()
         .to_number();

--- a/tests/sandbox_test.rs
+++ b/tests/sandbox_test.rs
@@ -41,7 +41,8 @@ fn sandbox_impl() -> Result<(), String> {
     output_dir.push("out/");
     fs::create_dir(output_dir.as_path()).map_err(|err| err.to_string())?;
 
-    Sandbox::new()
+    let engine = Engine::new().map_err(|err| err.to_string())?;
+    Sandbox::new(&engine)
         .and_then(|sandbox| sandbox.set_exec_args(vec!["test"]))
         .and_then(|sandbox| sandbox.load_input_files(input_dir.to_str().unwrap()))
         .and_then(|sandbox| sandbox.run(js.to_str().unwrap(), wasm.to_str().unwrap()))

--- a/tests/vfs_js_security_test.rs
+++ b/tests/vfs_js_security_test.rs
@@ -6,7 +6,8 @@ use std::path;
 #[test]
 fn vfs_js_security() {
     let engine = Engine::new().unwrap();
-    let result = engine.evaluate_script("writeFile('/tmp/test.txt', new Uint8Array(2))");
+    let runtime = Runtime::new(&engine).unwrap();
+    let result = runtime.evaluate_script("writeFile('/tmp/test.txt', new Uint8Array(2))");
 
     assert!(result.is_err());
     assert!(!path::Path::new("/tmp/test.txt").is_file());


### PR DESCRIPTION
This short PR refactors the internal structs for easier use and multi-threaded support. As such, what used to be `Engine` is now called `Runtime`, whereas `Engine` is now a wrapper struct for `Arc<JSEngine>`. This way, we don't force the user to learn about `rust-mozjs` crate if all they want to do is use our sandbox as a lib.